### PR TITLE
feat: Simplify context menu options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,12 @@ jobs:
             python=3.10
             pip=24.0
             jupyterlab
-            jupyterlite-core
-            jupyterlite-xeus>=4.4.0
+            ipywidgets
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          python -m pip install -U "jupyterlite-core==0.7.0" "jupyterlite-xeus==4.3.1"
 
       - name: Download extension package
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,9 +94,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
-          micromamba-version: "1.5.5-0"
+          micromamba-version: '2.3.2-0'
           environment-name: build-env
           create-args: >-
             python=3.10

--- a/demo/environment.yml
+++ b/demo/environment.yml
@@ -1,6 +1,6 @@
 name: xeus-kernels
 channels:
-  - https://repo.prefix.dev/emscripten-forge-dev
+  - https://repo.prefix.dev/emscripten-forge-4x
   - https://repo.prefix.dev/conda-forge
 dependencies:
   - xeus-python

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@jupyterlab/application": "^4.0.0",
-        "plainb": "^1.7.1"
+        "plainb": "^1.8.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.5.3",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,4 +1,5 @@
 import type { Contents, KernelSpec } from '@jupyterlab/services';
+import { detectFormat, parseFormat } from 'plainb';
 import type { Notebook } from 'plainb';
 import { PARSERS } from './parsers';
 import type { IRule, IKernelspec } from './parsers';
@@ -149,6 +150,51 @@ export async function convertFile(
     content: notebook
   });
 }
+
+export async function convertFileAuto(
+  contents: Contents.IManager,
+  filePath: string,
+  defaultKernelspec?: IKernelspec,
+  specs?: KernelSpec.ISpecModels | null,
+  outPath?: string
+): Promise<void> {
+  const model = await contents.get(filePath, {
+    type: 'file',
+    format: 'text',
+    content: true
+  });
+  const text = model.content as string;
+  const ext = filePath.slice(filePath.lastIndexOf('.'));
+  const format = detectFormat(text, ext);
+  const notebook = parseFormat(text, format) as any;
+
+  if (!notebook.metadata?.kernelspec) {
+    notebook.metadata = notebook.metadata ?? {};
+    const language = notebook.metadata?.language_info?.name || 'python';
+    const kernelspec =
+      extractKernelspecFromText(text) ??
+      defaultKernelspec ??
+      kernelspecFromLanguage(specs ?? null, language) ??
+      (language.toLowerCase() === 'python' ? DEFAULT_KERNELSPEC : undefined);
+    if (kernelspec) {
+      notebook.metadata.kernelspec = kernelspec;
+      if (!notebook.metadata.language_info) {
+        notebook.metadata.language_info = { name: kernelspec.language };
+      }
+    } else {
+      if (!notebook.metadata.language_info) {
+        notebook.metadata.language_info = { name: language };
+      }
+    }
+  }
+  const notebookPath = outPath ?? filePath.replace(/\.(py|md)$/, '.ipynb');
+  await contents.save(notebookPath, {
+    type: 'notebook',
+    format: 'json',
+    content: notebook
+  });
+}
+
 
 /**
  * Convert a .ipynb notebook to a plain text format using a serializer.

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -195,7 +195,6 @@ export async function convertFileAuto(
   });
 }
 
-
 /**
  * Convert a .ipynb notebook to a plain text format using a serializer.
  */

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,27 +2,53 @@ import { NotebookModel, NotebookModelFactory } from '@jupyterlab/notebook';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents, KernelSpec } from '@jupyterlab/services';
 import type { ISharedNotebook } from '@jupyter/ydoc';
-import type { Notebook } from 'plainb';
+import {
+  detectFormat,
+  parseClassicMd,
+  parseMystMd,
+  parsePy,
+  parseSphinxGallery,
+  toClassicMd,
+  toMystMd,
+  toPy,
+  toSphinxGallery
+} from 'plainb';
+import type { Notebook, PlainbFormat } from 'plainb';
 import {
   DEFAULT_KERNELSPEC,
   extractKernelspecFromText,
   kernelspecFromLanguage
 } from './convert';
 
+const PARSERS_BY_FORMAT: Record<PlainbFormat, (text: string) => object> = {
+  percent: parsePy,
+  'sphinx-gallery': parseSphinxGallery,
+  classic: parseClassicMd,
+  myst: parseMystMd
+};
+
+const SERIALIZERS_BY_FORMAT: Record<PlainbFormat, (notebook: Notebook) => string> =
+  {
+    percent: toPy,
+    'sphinx-gallery': toSphinxGallery,
+    classic: toClassicMd,
+    myst: toMystMd
+  };
+
 /**
- * A custom NotebookModel that parses and serializes from/to plain text.
+ * A custom NotebookModel that parses and serializes from/to plain text. The
+ * concrete format is auto-detected from the file extension and content, and
+ * remembered so the file round-trips back to the same format on save.
  */
 export class PlainTextNotebookModel extends NotebookModel {
   constructor(
     options: NotebookModel.IOptions & {
-      parser: (text: string) => object;
-      serializer: (notebook: Notebook) => string;
+      ext: string;
       specs?: KernelSpec.ISpecModels | null;
     }
   ) {
     super(options);
-    this._parser = options.parser;
-    this._serializer = options.serializer;
+    this._ext = options.ext;
     this._specs = options.specs ?? null;
   }
 
@@ -49,11 +75,12 @@ export class PlainTextNotebookModel extends NotebookModel {
       }
     }
 
-    return this._serializer(json as unknown as Notebook);
+    return SERIALIZERS_BY_FORMAT[this._format](json as unknown as Notebook);
   }
 
   fromString(value: string): void {
-    const notebook = this._parser(value) as any;
+    this._format = detectFormat(value, this._ext);
+    const notebook = PARSERS_BY_FORMAT[this._format](value) as any;
 
     // Ensure kernelspec is set
     if (!notebook.metadata?.kernelspec) {
@@ -78,8 +105,8 @@ export class PlainTextNotebookModel extends NotebookModel {
     super.fromJSON(notebook);
   }
 
-  private _parser: (text: string) => object;
-  private _serializer: (notebook: Notebook) => string;
+  private _ext: string;
+  private _format: PlainbFormat = 'percent';
   private _specs: KernelSpec.ISpecModels | null;
 }
 
@@ -90,15 +117,13 @@ export class PlainTextNotebookModelFactory extends NotebookModelFactory {
   constructor(
     options: NotebookModelFactory.IOptions & {
       name: string;
-      parser: (text: string) => object;
-      serializer: (notebook: Notebook) => string;
+      ext: string;
       specs?: KernelSpec.ISpecModels | null;
     }
   ) {
     super(options);
     this._name = options.name;
-    this._parser = options.parser;
-    this._serializer = options.serializer;
+    this._ext = options.ext;
     this._specs = options.specs ?? null;
   }
 
@@ -119,14 +144,12 @@ export class PlainTextNotebookModelFactory extends NotebookModelFactory {
   ): PlainTextNotebookModel {
     return new PlainTextNotebookModel({
       ...options,
-      parser: this._parser,
-      serializer: this._serializer,
+      ext: this._ext,
       specs: this._specs
     });
   }
 
   private _name: string;
-  private _parser: (text: string) => object;
-  private _serializer: (notebook: Notebook) => string;
+  private _ext: string;
   private _specs: KernelSpec.ISpecModels | null;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,38 +2,13 @@ import { NotebookModel, NotebookModelFactory } from '@jupyterlab/notebook';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents, KernelSpec } from '@jupyterlab/services';
 import type { ISharedNotebook } from '@jupyter/ydoc';
-import {
-  detectFormat,
-  parseClassicMd,
-  parseMystMd,
-  parsePy,
-  parseSphinxGallery,
-  toClassicMd,
-  toMystMd,
-  toPy,
-  toSphinxGallery
-} from 'plainb';
-import type { Notebook, PlainbFormat } from 'plainb';
+import { detectFormat, parseFormat, serializeFormat } from 'plainb';
+import type { PlainbFormat } from 'plainb';
 import {
   DEFAULT_KERNELSPEC,
   extractKernelspecFromText,
   kernelspecFromLanguage
 } from './convert';
-
-const PARSERS_BY_FORMAT: Record<PlainbFormat, (text: string) => object> = {
-  percent: parsePy,
-  'sphinx-gallery': parseSphinxGallery,
-  classic: parseClassicMd,
-  myst: parseMystMd
-};
-
-const SERIALIZERS_BY_FORMAT: Record<PlainbFormat, (notebook: Notebook) => string> =
-  {
-    percent: toPy,
-    'sphinx-gallery': toSphinxGallery,
-    classic: toClassicMd,
-    myst: toMystMd
-  };
 
 /**
  * A custom NotebookModel that parses and serializes from/to plain text. The
@@ -75,12 +50,12 @@ export class PlainTextNotebookModel extends NotebookModel {
       }
     }
 
-    return SERIALIZERS_BY_FORMAT[this._format](json as unknown as Notebook);
+    return serializeFormat(json, this._format);
   }
 
   fromString(value: string): void {
     this._format = detectFormat(value, this._ext);
-    const notebook = PARSERS_BY_FORMAT[this._format](value) as any;
+    const notebook = parseFormat(value, this._format) as any;
 
     // Ensure kernelspec is set
     if (!notebook.metadata?.kernelspec) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -25,6 +25,7 @@ import type {
 } from './parsers';
 import {
   convertFile,
+  convertFileAuto,
   convertNotebookToPlainText,
   autoConvert
 } from './convert';
@@ -232,12 +233,68 @@ export const plugin: JupyterFrontEndPlugin<void> = {
       });
     });
 
-    const convertSubmenu = new MenuSvg({ commands });
-    convertSubmenu.title.label = 'Convert to Notebook';
-    convertSubmenu.addItem({ command: 'ptjnb:convert-parsePy' });
-    convertSubmenu.addItem({ command: 'ptjnb:convert-parseSphinxGallery' });
-    convertSubmenu.addItem({ command: 'ptjnb:convert-parseClassicMd' });
-    convertSubmenu.addItem({ command: 'ptjnb:convert-parseMystMd' });
+    // Auto-detecting "Convert to Notebook" command
+    commands.addCommand('ptjnb:convert-to-notebook', {
+      label: 'Convert to Notebook',
+      icon: notebookFileType?.icon ?? notebookIcon,
+      isVisible: () => {
+        const browser = getCurrentBrowser();
+        if (!browser) {
+          return false;
+        }
+        const selection = browser.selectedItems();
+        const first = selection.next();
+        if (first.done || !first.value) {
+          return false;
+        }
+        const path = first.value.path;
+        return path.endsWith('.py') || path.endsWith('.md');
+      },
+      execute: async () => {
+        const browser = getCurrentBrowser();
+        if (!browser) {
+          return;
+        }
+        const selection = browser.selectedItems();
+        const first = selection.next();
+        if (first.done || !first.value) {
+          return;
+        }
+        const filePath = first.value.path;
+        const notebookPath = filePath.replace(/\.(py|md)$/, '.ipynb');
+        const contents = app.serviceManager.contents;
+        try {
+          let fileExists = false;
+          try {
+            await contents.get(notebookPath, { content: false });
+            fileExists = true;
+          } catch {
+            /* empty */
+          }
+          if (fileExists) {
+            const result = await showDialog({
+              title: 'Overwrite notebook?',
+              body: `"${notebookPath}" already exists. Overwrite it?`,
+              buttons: [
+                Dialog.cancelButton(),
+                Dialog.warnButton({ label: 'Overwrite' })
+              ]
+            });
+            if (!result.button.accept) {
+              return;
+            }
+          }
+          await convertFileAuto(
+            contents,
+            filePath,
+            defaultKernelspec,
+            specs
+          );
+        } catch (e) {
+          console.error('ptjnb: conversion failed', e);
+        }
+      }
+    });
 
     [
       '.jp-DirListing-item[data-isdir="false"][data-file-type="python"]',
@@ -246,8 +303,7 @@ export const plugin: JupyterFrontEndPlugin<void> = {
       '.jp-DirListing-item[data-isdir="false"][data-file-type="ptjnb-md"]'
     ].forEach(selector => {
       contextMenu.addItem({
-        type: 'submenu',
-        submenu: convertSubmenu,
+        command: 'ptjnb:convert-to-notebook',
         selector,
         rank: 10
       });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -102,11 +102,14 @@ export const plugin: JupyterFrontEndPlugin<void> = {
     const notebookFileType = app.docRegistry.getFileType('notebook');
 
     // Register one auto-detecting "Notebook" widget factory per extension
-    const EXTENSIONS: Array<{ ext: string; fileTypeName: string; modelName: string }> =
-      [
-        { ext: '.py', fileTypeName: 'ptjnb-py', modelName: 'ptjnb-model-py' },
-        { ext: '.md', fileTypeName: 'ptjnb-md', modelName: 'ptjnb-model-md' }
-      ];
+    const EXTENSIONS: Array<{
+      ext: string;
+      fileTypeName: string;
+      modelName: string;
+    }> = [
+      { ext: '.py', fileTypeName: 'ptjnb-py', modelName: 'ptjnb-model-py' },
+      { ext: '.md', fileTypeName: 'ptjnb-md', modelName: 'ptjnb-model-md' }
+    ];
 
     for (const { ext, fileTypeName, modelName } of EXTENSIONS) {
       app.docRegistry.addFileType({
@@ -284,12 +287,7 @@ export const plugin: JupyterFrontEndPlugin<void> = {
               return;
             }
           }
-          await convertFileAuto(
-            contents,
-            filePath,
-            defaultKernelspec,
-            specs
-          );
+          await convertFileAuto(contents, filePath, defaultKernelspec, specs);
         } catch (e) {
           console.error('ptjnb: conversion failed', e);
         }
@@ -386,7 +384,8 @@ export const plugin: JupyterFrontEndPlugin<void> = {
     contextMenu.addItem({
       type: 'submenu',
       submenu: exportSubmenu,
-      selector: '.jp-DirListing-item[data-isdir="false"][data-file-type="notebook"]',
+      selector:
+        '.jp-DirListing-item[data-isdir="false"][data-file-type="notebook"]',
       rank: 11
     });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,13 +11,12 @@ import {
 } from '@jupyterlab/apputils';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { PageConfig } from '@jupyterlab/coreutils';
-import { MenuSvg } from '@jupyterlab/ui-components';
+import { MenuSvg, notebookIcon } from '@jupyterlab/ui-components';
 import {
   PARSERS,
   PARSER_LABELS,
   PARSER_EXTENSIONS,
-  SERIALIZERS,
-  CONTEXT_MENU_LABELS
+  SERIALIZERS
 } from './parsers';
 import type {
   ParserName,
@@ -99,35 +98,35 @@ export const plugin: JupyterFrontEndPlugin<void> = {
 
     let ptjnbId = 0;
 
-    (Object.keys(PARSERS) as ParserName[]).forEach(parserName => {
-      const convertCommandId = `ptjnb:convert-${parserName}`;
-      const parser = PARSERS[parserName];
-      const exts = PARSER_EXTENSIONS[parserName];
-      const serializer = SERIALIZERS[parserName];
+    const notebookFileType = app.docRegistry.getFileType('notebook');
 
-      // Names must be lowercase because preferredWidgetFactories is case sensitive
-      const fileTypeName = `ptjnb-${parserName}`.toLowerCase();
-      const modelName = `ptjnb-model-${parserName}`.toLowerCase();
-      const widgetFactoryName = CONTEXT_MENU_LABELS[parserName];
+    // Register one auto-detecting "Notebook" widget factory per extension
+    const EXTENSIONS: Array<{ ext: string; fileTypeName: string; modelName: string }> =
+      [
+        { ext: '.py', fileTypeName: 'ptjnb-py', modelName: 'ptjnb-model-py' },
+        { ext: '.md', fileTypeName: 'ptjnb-md', modelName: 'ptjnb-model-md' }
+      ];
 
+    for (const { ext, fileTypeName, modelName } of EXTENSIONS) {
       app.docRegistry.addFileType({
         name: fileTypeName,
-        extensions: exts,
+        extensions: [ext],
         contentType: 'file',
-        fileFormat: 'text'
+        fileFormat: 'text',
+        icon: notebookFileType?.icon ?? notebookIcon
       });
 
       app.docRegistry.addModelFactory(
         new PlainTextNotebookModelFactory({
           name: modelName,
-          parser,
-          serializer,
+          ext,
           specs
         })
       );
 
       const widgetFactory = new NotebookWidgetFactory({
-        name: widgetFactoryName,
+        name: fileTypeName,
+        label: 'Notebook',
         modelName,
         fileTypes: [fileTypeName],
         defaultFor: [],
@@ -143,7 +142,9 @@ export const plugin: JupyterFrontEndPlugin<void> = {
       // Register each created panel with the notebook tracker.
       widgetFactory.widgetCreated.connect((_sender, widget) => {
         widget.id = widget.id || `ptjnb-${++ptjnbId}`;
-        widget.title.icon = undefined;
+        widget.title.icon = notebookFileType?.icon ?? notebookIcon;
+        widget.title.iconClass = notebookFileType?.iconClass ?? '';
+        widget.title.iconLabel = notebookFileType?.iconLabel ?? '';
 
         if (notebookTracker) {
           const tracker = notebookTracker as NotebookTracker;
@@ -157,10 +158,17 @@ export const plugin: JupyterFrontEndPlugin<void> = {
 
       // Copy any other widget extensions
       void app.restored.then(() => {
-        for (const ext of app.docRegistry.widgetExtensions('Notebook')) {
-          app.docRegistry.addWidgetExtension(widgetFactoryName, ext);
+        for (const e of app.docRegistry.widgetExtensions('Notebook')) {
+          app.docRegistry.addWidgetExtension(fileTypeName, e);
         }
       });
+    }
+
+    // "Convert to Notebook" commands keep an explicit per-format choice.
+    (Object.keys(PARSERS) as ParserName[]).forEach(parserName => {
+      const convertCommandId = `ptjnb:convert-${parserName}`;
+      const parser = PARSERS[parserName];
+      const exts = PARSER_EXTENSIONS[parserName];
 
       commands.addCommand(convertCommandId, {
         label: PARSER_LABELS[parserName],
@@ -231,11 +239,18 @@ export const plugin: JupyterFrontEndPlugin<void> = {
     convertSubmenu.addItem({ command: 'ptjnb:convert-parseClassicMd' });
     convertSubmenu.addItem({ command: 'ptjnb:convert-parseMystMd' });
 
-    contextMenu.addItem({
-      type: 'submenu',
-      submenu: convertSubmenu,
-      selector: '.jp-DirListing-item[data-isdir="false"]',
-      rank: 10
+    [
+      '.jp-DirListing-item[data-isdir="false"][data-file-type="python"]',
+      '.jp-DirListing-item[data-isdir="false"][data-file-type="markdown"]',
+      '.jp-DirListing-item[data-isdir="false"][data-file-type="ptjnb-py"]',
+      '.jp-DirListing-item[data-isdir="false"][data-file-type="ptjnb-md"]'
+    ].forEach(selector => {
+      contextMenu.addItem({
+        type: 'submenu',
+        submenu: convertSubmenu,
+        selector,
+        rank: 10
+      });
     });
 
     // Reverse conversion: .ipynb to plain text
@@ -315,7 +330,7 @@ export const plugin: JupyterFrontEndPlugin<void> = {
     contextMenu.addItem({
       type: 'submenu',
       submenu: exportSubmenu,
-      selector: '.jp-DirListing-item[data-isdir="false"]',
+      selector: '.jp-DirListing-item[data-isdir="false"][data-file-type="notebook"]',
       rank: 11
     });
 

--- a/ui-tests/tests/ptjnb.spec.ts
+++ b/ui-tests/tests/ptjnb.spec.ts
@@ -139,9 +139,7 @@ test.describe('ptjnb open-with', () => {
       .filter({ hasText: 'Open With' })
       .hover();
     await expect(
-      page
-        .locator('.lm-Menu-itemLabel')
-        .filter({ hasText: 'Notebook' })
+      page.locator('.lm-Menu-itemLabel').filter({ hasText: 'Notebook' })
     ).toBeVisible();
   });
 
@@ -169,11 +167,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'image_processing.py')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(
-      page,
-      'image_processing.py',
-      'Notebook'
-    );
+    await openWithNotebook(page, 'image_processing.py', 'Notebook');
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT
@@ -190,11 +184,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'classic_demo.md')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(
-      page,
-      'classic_demo.md',
-      'Notebook'
-    );
+    await openWithNotebook(page, 'classic_demo.md', 'Notebook');
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT

--- a/ui-tests/tests/ptjnb.spec.ts
+++ b/ui-tests/tests/ptjnb.spec.ts
@@ -22,12 +22,15 @@ function fileItem(page: Page, name: string) {
   return page.locator('.jp-DirListing-item').filter({ hasText: name }).first();
 }
 
-async function openConvertSubmenu(page: Page, fileName: string): Promise<void> {
+async function clickConvertToNotebook(
+  page: Page,
+  fileName: string
+): Promise<void> {
   await fileItem(page, fileName).click({ button: 'right' });
   await page
     .locator('.lm-Menu-itemLabel')
     .filter({ hasText: 'Convert to Notebook' })
-    .hover();
+    .click();
 }
 
 async function openPlainTextSubmenu(
@@ -84,11 +87,7 @@ test.describe('ptjnb', () => {
   });
 
   test('converts .py to .ipynb when no sibling exists', async ({ page }) => {
-    await openConvertSubmenu(page, 'complicated.py');
-    await page
-      .locator('.lm-Menu-itemLabel')
-      .filter({ hasText: 'Percent format (.py)' })
-      .click();
+    await clickConvertToNotebook(page, 'complicated.py');
     await expect(fileItem(page, 'complicated.ipynb')).toBeVisible({
       timeout: CONVERT_TIMEOUT
     });
@@ -102,11 +101,7 @@ test.describe('ptjnb', () => {
     await expect(fileItem(page, 'numpy_demo.ipynb')).toBeVisible({
       timeout: CONVERT_TIMEOUT
     });
-    await openConvertSubmenu(page, 'numpy_demo.py');
-    await page
-      .locator('.lm-Menu-itemLabel')
-      .filter({ hasText: 'Percent format (.py)' })
-      .click();
+    await clickConvertToNotebook(page, 'numpy_demo.py');
     await expect(page.locator('.jp-Dialog-header')).toContainText(
       'Overwrite notebook?'
     );
@@ -120,11 +115,7 @@ test.describe('ptjnb', () => {
     await expect(fileItem(page, 'numpy_demo.ipynb')).toBeVisible({
       timeout: CONVERT_TIMEOUT
     });
-    await openConvertSubmenu(page, 'numpy_demo.py');
-    await page
-      .locator('.lm-Menu-itemLabel')
-      .filter({ hasText: 'Percent format (.py)' })
-      .click();
+    await clickConvertToNotebook(page, 'numpy_demo.py');
     await expect(page.locator('.jp-Dialog')).toBeVisible();
     await page.locator('.jp-Dialog-footer .jp-mod-reject').click();
     await expect(page.locator('.jp-Dialog')).toBeHidden();
@@ -150,7 +141,7 @@ test.describe('ptjnb open-with', () => {
     await expect(
       page
         .locator('.lm-Menu-itemLabel')
-        .filter({ hasText: 'Notebook (Percent .py)' })
+        .filter({ hasText: 'Notebook' })
     ).toBeVisible();
   });
 
@@ -161,7 +152,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'numpy_demo.py')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(page, 'numpy_demo.py', 'Notebook (Percent .py)');
+    await openWithNotebook(page, 'numpy_demo.py', 'Notebook');
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT
@@ -181,7 +172,7 @@ test.describe('ptjnb open-with', () => {
     await openWithNotebook(
       page,
       'image_processing.py',
-      'Notebook (Sphinx Gallery .py)'
+      'Notebook'
     );
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
@@ -202,7 +193,7 @@ test.describe('ptjnb open-with', () => {
     await openWithNotebook(
       page,
       'classic_demo.md',
-      'Notebook (Classic Markdown .md)'
+      'Notebook'
     );
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
@@ -220,7 +211,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'myst_demo.md')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(page, 'myst_demo.md', 'Notebook (MyST .md)');
+    await openWithNotebook(page, 'myst_demo.md', 'Notebook');
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT
@@ -256,11 +247,7 @@ test.describe('ptjnb export', () => {
     const pyFile = fileItem(page, 'complicated.py');
     await expect(pyFile).toBeVisible({ timeout: FILE_BROWSER_TIMEOUT });
 
-    await openConvertSubmenu(page, 'complicated.py');
-    await page
-      .locator('.lm-Menu-itemLabel')
-      .filter({ hasText: 'Percent format (.py)' })
-      .click();
+    await clickConvertToNotebook(page, 'complicated.py');
 
     // If complicated.ipynb already exists from a previous test, dismiss the overwrite dialog
     const overwriteNbDialog = page.locator('.jp-Dialog-header');

--- a/ui-tests/tests/ptjnb.spec.ts
+++ b/ui-tests/tests/ptjnb.spec.ts
@@ -47,7 +47,7 @@ async function openPlainTextSubmenu(
 async function openWithNotebook(
   page: Page,
   fileName: string,
-  factoryLabel: string
+  factoryLabel: string | RegExp
 ): Promise<void> {
   await fileItem(page, fileName).click({ button: 'right' });
   await page
@@ -139,7 +139,7 @@ test.describe('ptjnb open-with', () => {
       .filter({ hasText: 'Open With' })
       .hover();
     await expect(
-      page.locator('.lm-Menu-itemLabel').filter({ hasText: 'Notebook' })
+      page.locator('.lm-Menu-itemLabel').filter({ hasText: /^Notebook$/ })
     ).toBeVisible();
   });
 
@@ -150,7 +150,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'numpy_demo.py')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(page, 'numpy_demo.py', 'Notebook');
+    await openWithNotebook(page, 'numpy_demo.py', /^Notebook$/);
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT
@@ -167,7 +167,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'image_processing.py')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(page, 'image_processing.py', 'Notebook');
+    await openWithNotebook(page, 'image_processing.py', /^Notebook$/);
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT
@@ -184,7 +184,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'classic_demo.md')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(page, 'classic_demo.md', 'Notebook');
+    await openWithNotebook(page, 'classic_demo.md', /^Notebook$/);
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT
@@ -201,7 +201,7 @@ test.describe('ptjnb open-with', () => {
     await expect(fileItem(page, 'myst_demo.md')).toBeVisible({
       timeout: FILE_BROWSER_TIMEOUT
     });
-    await openWithNotebook(page, 'myst_demo.md', 'Notebook');
+    await openWithNotebook(page, 'myst_demo.md', /^Notebook$/);
 
     await expect(page.locator('.jp-NotebookPanel-toolbar')).toBeVisible({
       timeout: CONVERT_TIMEOUT

--- a/yarn.lock
+++ b/yarn.lock
@@ -8857,10 +8857,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plainb@npm:^1.7.1":
-  version: 1.7.1
-  resolution: "plainb@npm:1.7.1"
-  checksum: 6183a6d94127e5be8535f82432178361a986125247e8f3ffe08b3f6f83e1223c867908148c62ce2145b112add43777b0594fde3a6818e77b856f5f5cec96799e
+"plainb@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "plainb@npm:1.8.0"
+  checksum: 7615d9412553740a9307d663197824719a73e0f06b5977a21d3491c1009dc84f4350279bbef5fc0bc5ce08128fa771e2047fc43b692e6fc4dfe6161e28720813
   languageName: node
   linkType: hard
 
@@ -9088,7 +9088,7 @@ __metadata:
     eslint-plugin-prettier: ^5.0.0
     jest: ^29.2.0
     npm-run-all2: ^7.0.1
-    plainb: ^1.7.1
+    plainb: ^1.8.0
     prettier: ^3.0.0
     rimraf: ^5.0.1
     source-map-loader: ^1.0.2


### PR DESCRIPTION
This PR uses the new version of plainb which has format detection, to simplify the context menu options when opening plaintext files as notebook:
-For the "Open With" context menu option, you just get "Notebook" instead of two entries for each format.
-Same thing for the "Convert to Notebook" option which no longer has any sub entries.

Here is a screencast of the new context menu:
https://github.com/user-attachments/assets/6955ca75-18b9-4a04-a33b-7a7ccaacdb65

